### PR TITLE
Rename network module and enable Async ElegantOTA

### DIFF
--- a/DigifizAP/DigifizAP.ino
+++ b/DigifizAP/DigifizAP.ino
@@ -1,5 +1,5 @@
 #include "commands.h"
-#include "network.h"
+#include "miniuiod_wifi.h"
 
 // Board pins
 constexpr uint8_t RELAY_PIN1 = 32;

--- a/DigifizAP/commands.cpp
+++ b/DigifizAP/commands.cpp
@@ -1,5 +1,5 @@
 #include "commands.h"
-#include "network.h"
+#include "miniuiod_wifi.h"
 #include "protocol.h"
 
 int getAllDataFlag = 0;

--- a/DigifizAP/miniuiod_wifi.cpp
+++ b/DigifizAP/miniuiod_wifi.cpp
@@ -1,4 +1,4 @@
-#include "network.h"
+#include "miniuiod_wifi.h"
 #include "commands.h"
 #include <ESPmDNS.h>
 #include <ElegantOTA.h>

--- a/DigifizAP/miniuiod_wifi.h
+++ b/DigifizAP/miniuiod_wifi.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#ifndef ELEGANTOTA_USE_ASYNC_WEBSERVER
+#define ELEGANTOTA_USE_ASYNC_WEBSERVER
+#endif
+
 #include <ESPAsyncWebServer.h>
 
 extern AsyncWebServer server;


### PR DESCRIPTION
## Summary
- Rename network files to `miniuiod_wifi` for clearer role
- Define `ELEGANTOTA_USE_ASYNC_WEBSERVER` globally so ElegantOTA uses AsyncWebServer
- Update includes to new file names across project

## Testing
- `arduino-cli compile ./DigifizAP` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f2f808dcc8323adfe20e4bfc8cfa0