### PR TITLE
Embed firmware update iframe

### DIFF
--- a/DigifizAP/data/index.html
+++ b/DigifizAP/data/index.html
@@ -284,10 +284,12 @@
   </div>
   <div id="firmware" class="tab-pane fade"
        role="tabpanel" aria-labelledby="firmware-tab">
-    <h3>Firmware Update</h3>
-    <p>Coming soon</p>
-    <button class="btn btn-primary" disabled>OTA Update</button>
-    <button class="btn btn-primary" disabled>SPIFFS Update</button>
+    <iframe id="updateFrame" src=""
+            style="width:100%;min-height:600px;border:0;"></iframe>
+    <script>
+      document.getElementById('updateFrame').src =
+        'http://' + window.location.hostname + '/update';
+    </script>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
- load firmware update UI through an iframe pointing to the device's /update path

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ae7c4bf88323bafd5e64251018cb