### PR TITLE
Pin ESP32 core version for CI compatibility

### DIFF
--- a/.github/workflows/esp32-build.yml
+++ b/.github/workflows/esp32-build.yml
@@ -23,7 +23,8 @@ jobs:
       - name: Install ESP32 platform
         run: |
           arduino-cli core update-index
-          arduino-cli core install esp32:esp32
+          # Use ESP32 core version 2.0.9 to ensure compatibility with libraries
+          arduino-cli core install esp32:esp32@2.0.9
 
       - name: Install libraries
         run: |


### PR DESCRIPTION
## Summary
- Pin ESP32 Arduino core to version 2.0.9 to avoid mbedTLS MD5 API mismatch.

## Testing
- `curl -L https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | sh` *(failed: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a1fc800908832380599fff8ebb1cf6